### PR TITLE
[Ecore][Cpp] Define EContentAdapter class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,7 @@
 ---
 AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignOperands: true
 AllowShortFunctionsOnASingleLine: None
 AlwaysBreakTemplateDeclarations: true
 BinPackParameters: false
@@ -7,6 +9,7 @@ BinPackArguments: false
 BreakBeforeBinaryOperators: true
 BreakBeforeBraces: Allman
 BreakConstructorInitializersBeforeComma: true
+BreakBeforeTernaryOperators: true
 ColumnLimit: 140
 IndentCaseLabels: false
 IndentWidth: 4

--- a/ecore/lib/CMakeFiles.txt
+++ b/ecore/lib/CMakeFiles.txt
@@ -6,6 +6,7 @@ set(SOURCE_ECORE_FILES
     src/ecore/EResourceFactoryRegistry.cpp
     src/ecore/URI.cpp
     src/ecore/EcoreUtils.cpp
+    src/ecore/EContentAdapter.cpp
 )
 
 set(HEADER_ECORE_FILES
@@ -16,6 +17,7 @@ set(HEADER_ECORE_FILES
     src/ecore/EList.inl
     src/ecore/Constants.hpp
     src/ecore/EAdapter.hpp
+    src/ecore/EContentAdapter.hpp
     src/ecore/EcoreUtils.hpp
     src/ecore/ECollectionView.hpp
     src/ecore/EDiagnostic.hpp

--- a/ecore/lib/src/ecore/AnyCast.hpp
+++ b/ecore/lib/src/ecore/AnyCast.hpp
@@ -11,8 +11,9 @@
 #define ECORE_ANYCAST_HPP_
 
 #include "ecore/Any.hpp"
-#include "ecore/EObject.hpp"
 #include "ecore/EList.hpp"
+#include "ecore/EObject.hpp"
+#include "ecore/SmartPtr.hpp"
 #include "ecore/TypeTraits.hpp"
 
 namespace ecore
@@ -24,7 +25,7 @@ namespace ecore
         if( id == &typeid( std::shared_ptr<EObject> ) )
         {
             auto object = anyCast<std::shared_ptr<EObject>>( any );
-            return std::dynamic_pointer_cast<typename T::element_type>( object );
+            return derived_pointer_cast<typename T::element_type>( object );
         }
         else if( id == &typeid( T ) )
             return anyCast<T>( any );

--- a/ecore/lib/src/ecore/EAdapter.hpp
+++ b/ecore/lib/src/ecore/EAdapter.hpp
@@ -19,19 +19,21 @@ namespace ecore
 
     class ENotification;
     class ENotifier;
-    
+
     class ECORE_API EAdapter
     {
     public:
         virtual ~EAdapter() = default;
 
-        virtual void notifyChanged(const std::shared_ptr<ENotification>& notification) = 0;
+        virtual void notifyChanged( const std::shared_ptr<ENotification>& notification ) = 0;
 
         virtual std::shared_ptr<ENotifier> getTarget() const = 0;
 
-        virtual void setTarget(const std::shared_ptr<ENotifier>& target) = 0;
+        virtual void setTarget( const std::shared_ptr<ENotifier>& target ) = 0;
+
+        virtual void unsetTarget( const std::shared_ptr<ENotifier>& target ) = 0;
     };
 
-}
+} // namespace ecore
 
 #endif

--- a/ecore/lib/src/ecore/EContentAdapter.cpp
+++ b/ecore/lib/src/ecore/EContentAdapter.cpp
@@ -3,6 +3,7 @@
 #include "ecore/EList.hpp"
 #include "ecore/ENotification.hpp"
 #include "ecore/EObject.hpp"
+#include "ecore/EReference.hpp"
 #include "ecore/Stream.hpp"
 #include "ecore/impl/EObjectInternal.hpp"
 
@@ -61,6 +62,14 @@ void EContentAdapter::removeAdapter( const std::shared_ptr<EObject>& eObject, bo
 }
 
 void EContentAdapter::selfAdapt( const std::shared_ptr<ENotification>& notification )
+{
+    auto feature = notification->getFeature();
+    auto reference = std::dynamic_pointer_cast<EReference>( feature );
+    if( reference && reference->isContainment() )
+        handleContainment( notification );
+}
+
+void ecore::EContentAdapter::handleContainment( const std::shared_ptr<ENotification>& notification )
 {
     switch( notification->getEventType() )
     {

--- a/ecore/lib/src/ecore/EContentAdapter.cpp
+++ b/ecore/lib/src/ecore/EContentAdapter.cpp
@@ -98,7 +98,7 @@ void ecore::EContentAdapter::handleContainment( const std::shared_ptr<ENotificat
         auto oldValue = notification->getOldValue();
         if( oldValue.type() != typeid( bool ) )
         {
-            removeAdapter( anyCast<std::shared_ptr<EObject>>( notification->getOldValue() ), true );
+            removeAdapter( anyCast<std::shared_ptr<EObject>>( notification->getOldValue() ) );
             addAdapter( anyCast<std::shared_ptr<EObject>>( notification->getNewValue() ) );
         }
         break;

--- a/ecore/lib/src/ecore/EContentAdapter.cpp
+++ b/ecore/lib/src/ecore/EContentAdapter.cpp
@@ -103,9 +103,12 @@ void EContentAdapter::selfAdapt( const std::shared_ptr<ENotification>& notificat
     }
     case ENotification::ADD_MANY:
     {
-        std::vector<std::shared_ptr<EObject>> notifiers = anyCast<std::vector<std::shared_ptr<EObject>>>( notification->getNewValue() );
-        for( auto& notifier : notifiers )
+        std::vector<Any> newValues = anyCast<std::vector<Any>>( notification->getNewValue() );
+        for( auto& newValue : newValues )
+        {
+            auto notifier = anyCast<std::shared_ptr<EObject>>( newValue );
             addAdapter( notifier );
+        }
         break;
     }
     case ENotification::REMOVE:
@@ -115,9 +118,12 @@ void EContentAdapter::selfAdapt( const std::shared_ptr<ENotification>& notificat
     }
     case ENotification::REMOVE_MANY:
     {
-        std::vector<std::shared_ptr<EObject>> notifiers = anyCast<std::vector<std::shared_ptr<EObject>>>( notification->getOldValue() );
-        for( auto& notifier : notifiers )
+        std::vector<Any> oldValues = anyCast<std::vector<Any>>( notification->getOldValue() );
+        for( auto& oldValue : oldValues )
+        {
+            auto notifier = anyCast<std::shared_ptr<EObject>>( oldValue );
             removeAdapter( notifier );
+        }
         break;
     }
     }

--- a/ecore/lib/src/ecore/EContentAdapter.cpp
+++ b/ecore/lib/src/ecore/EContentAdapter.cpp
@@ -1,0 +1,124 @@
+#include "ecore/EContentAdapter.hpp"
+#include "ecore/Any.hpp"
+#include "ecore/EList.hpp"
+#include "ecore/ENotification.hpp"
+#include "ecore/EObject.hpp"
+#include "ecore/Stream.hpp"
+#include "ecore/impl/EObjectInternal.hpp"
+
+#include <vector>
+
+using namespace ecore;
+using namespace ecore::impl;
+
+void EContentAdapter::notifyChanged( const std::shared_ptr<ENotification>& notification )
+{
+    selfAdapt( notification );
+}
+
+void EContentAdapter::setTarget( const std::shared_ptr<ENotifier>& newTarget )
+{
+    auto oldTarget = AbstractAdapter::getTarget();
+    if( oldTarget )
+    {
+        auto eObject = std::static_pointer_cast<EObject>( oldTarget );
+        auto eContents = eObject->eContents();
+        for( auto& eContent : *eContents )
+            removeAdapter( eContent );
+    }
+    AbstractAdapter::setTarget( newTarget );
+    if( newTarget )
+    {
+        auto eObject = std::static_pointer_cast<EObject>( newTarget );
+        auto eContents = eObject->eContents();
+        for( auto& eContent : *eContents )
+            addAdapter( eContent );
+    }    
+}
+
+void EContentAdapter::addAdapter( const std::shared_ptr<EObject>& eObject )
+{
+    if( !eObject )
+        return;
+
+    auto& eAdapters = eObject->eAdapters();
+    if( !eAdapters.contains( this ) )
+        eAdapters.add( this );
+}
+
+void EContentAdapter::removeAdapter( const std::shared_ptr<EObject>& eObject, bool checkContainer )
+{
+    if( !eObject )
+        return;
+
+    if( checkContainer )
+    {
+        auto container = eObject->getInternal().eInternalContainer();
+        if( container && container->eAdapters().contains( this ) )
+            return;
+    }
+    eObject->eAdapters().remove( this );
+}
+
+void EContentAdapter::selfAdapt( const std::shared_ptr<ENotification>& notification )
+{
+    switch( notification->getEventType() )
+    {
+    case ENotification::RESOLVE:
+    {
+        // We need to be careful that the proxy may be resolved while we are attaching this adapter.
+        // We need to avoid attaching the adapter during the resolve
+        // and also attaching it again as we walk the eContents() later.
+        // Checking here avoids having to check during addAdapter.
+        //
+        auto oldValue = anyCast<std::shared_ptr<EObject>>( notification->getOldValue() );
+        if( oldValue->eAdapters().contains( this ) )
+        {
+            removeAdapter( oldValue );
+            auto newValue = anyCast<std::shared_ptr<EObject>>( notification->getNewValue() );
+            addAdapter( newValue );
+        }
+        break;
+    }
+    case ENotification::UNSET:
+    {
+        auto oldValue = notification->getOldValue();
+        if( oldValue.type() != typeid( bool ) )
+        {
+            removeAdapter( anyCast<std::shared_ptr<EObject>>( notification->getOldValue() ), true );
+            addAdapter( anyCast<std::shared_ptr<EObject>>( notification->getNewValue() ) );
+        }
+        break;
+    }
+    case ENotification::SET:
+    {
+        removeAdapter( anyCast<std::shared_ptr<EObject>>( notification->getOldValue() ) );
+        addAdapter( anyCast<std::shared_ptr<EObject>>( notification->getNewValue() ) );
+        break;
+    }
+    case ENotification::ADD:
+    {
+        addAdapter( anyCast<std::shared_ptr<EObject>>( notification->getNewValue() ) );
+        break;
+    }
+    case ENotification::ADD_MANY:
+    {
+        std::vector<std::shared_ptr<EObject>> notifiers = anyCast<std::vector<std::shared_ptr<EObject>>>( notification->getNewValue() );
+        for( auto& notifier : notifiers )
+            addAdapter( notifier );
+        break;
+    }
+    case ENotification::REMOVE:
+    {
+        removeAdapter( anyCast<std::shared_ptr<EObject>>( notification->getOldValue() ) );
+        break;
+    }
+    case ENotification::REMOVE_MANY:
+    {
+        std::vector<std::shared_ptr<EObject>> notifiers = anyCast<std::vector<std::shared_ptr<EObject>>>( notification->getOldValue() );
+        for( auto& notifier : notifiers )
+            removeAdapter( notifier );
+        break;
+    }
+    }
+}

--- a/ecore/lib/src/ecore/EContentAdapter.cpp
+++ b/ecore/lib/src/ecore/EContentAdapter.cpp
@@ -19,14 +19,6 @@ void EContentAdapter::notifyChanged( const std::shared_ptr<ENotification>& notif
 
 void EContentAdapter::setTarget( const std::shared_ptr<ENotifier>& newTarget )
 {
-    auto oldTarget = AbstractAdapter::getTarget();
-    if( oldTarget )
-    {
-        auto eObject = std::static_pointer_cast<EObject>( oldTarget );
-        auto eContents = eObject->eContents();
-        for( auto& eContent : *eContents )
-            removeAdapter( eContent );
-    }
     AbstractAdapter::setTarget( newTarget );
     if( newTarget )
     {
@@ -35,6 +27,18 @@ void EContentAdapter::setTarget( const std::shared_ptr<ENotifier>& newTarget )
         for( auto& eContent : *eContents )
             addAdapter( eContent );
     }    
+}
+
+void EContentAdapter::unsetTarget( const std::shared_ptr<ENotifier>& oldTarget )
+{
+    AbstractAdapter::unsetTarget( oldTarget );
+    if( oldTarget )
+    {
+        auto eObject = std::static_pointer_cast<EObject>( oldTarget );
+        auto eContents = eObject->eContents();
+        for( auto& eContent : *eContents )
+            removeAdapter( eContent );
+    }
 }
 
 void EContentAdapter::addAdapter( const std::shared_ptr<EObject>& eObject )

--- a/ecore/lib/src/ecore/EContentAdapter.hpp
+++ b/ecore/lib/src/ecore/EContentAdapter.hpp
@@ -38,6 +38,8 @@ namespace ecore
     private:
         void selfAdapt( const std::shared_ptr<ENotification>& notification );
 
+        void handleContainment( const std::shared_ptr<ENotification>& notification );
+
         void addAdapter( const std::shared_ptr<EObject>& eObject );
 
         void removeAdapter( const std::shared_ptr<EObject>& eObject , bool checkContainer = false );

--- a/ecore/lib/src/ecore/EContentAdapter.hpp
+++ b/ecore/lib/src/ecore/EContentAdapter.hpp
@@ -34,6 +34,8 @@ namespace ecore
         virtual void notifyChanged( const std::shared_ptr<ENotification>& notification );
 
         virtual void setTarget( const std::shared_ptr<ENotifier>& target );
+        
+        virtual void unsetTarget( const std::shared_ptr<ENotifier>& target );
 
     private:
         void selfAdapt( const std::shared_ptr<ENotification>& notification );

--- a/ecore/lib/src/ecore/EContentAdapter.hpp
+++ b/ecore/lib/src/ecore/EContentAdapter.hpp
@@ -1,0 +1,48 @@
+// *****************************************************************************
+//
+// This file is part of a MASA library or program.
+// Refer to the included end-user license agreement for restrictions.
+//
+// Copyright (c) 2020 MASA Group
+//
+// *****************************************************************************
+
+#ifndef ECORE_ECONTENTADAPTER_HPP_
+#define ECORE_ECONTENTADAPTER_HPP_
+
+#include "ecore/Exports.hpp"
+#include "ecore/impl/AbstractAdapter.hpp"
+
+#include <memory>
+
+namespace ecore
+{
+    class EObject;
+
+    /**
+     * An adapter that maintains itself as an adapter for all contained objects
+     * as they come and go.
+     * It can be installed for an {@link EObject}
+     */
+    class ECORE_API EContentAdapter : public impl::AbstractAdapter
+    {
+    public:
+        EContentAdapter() = default;
+        
+        virtual ~EContentAdapter() = default;
+
+        virtual void notifyChanged( const std::shared_ptr<ENotification>& notification );
+
+        virtual void setTarget( const std::shared_ptr<ENotifier>& target );
+
+    private:
+        void selfAdapt( const std::shared_ptr<ENotification>& notification );
+
+        void addAdapter( const std::shared_ptr<EObject>& eObject );
+
+        void removeAdapter( const std::shared_ptr<EObject>& eObject , bool checkContainer = false );
+    };
+
+} // namespace ecore
+
+#endif

--- a/ecore/lib/src/ecore/EList.hpp
+++ b/ecore/lib/src/ecore/EList.hpp
@@ -10,22 +10,26 @@
 #ifndef ECORE_ELIST_HPP_
 #define ECORE_ELIST_HPP_
 
-#include <memory>
 #include "ecore/Assert.hpp"
+#include <memory>
 
-namespace ecore {
+namespace ecore
+{
 
     template <typename T>
-    class EList : public std::enable_shared_from_this< EList<T> >{
+    class EList : public std::enable_shared_from_this<EList<T>>
+    {
     public:
         typedef typename T ValueType;
 
-        virtual ~EList() {}
+        virtual ~EList()
+        {
+        }
 
         virtual bool add( const T& e ) = 0;
 
         virtual bool addAll( const EList<T>& l ) = 0;
-        
+
         virtual bool add( std::size_t pos, const T& e ) = 0;
 
         virtual bool addAll( std::size_t pos, const EList<T>& l ) = 0;
@@ -48,78 +52,87 @@ namespace ecore {
 
         virtual bool empty() const = 0;
 
-        virtual bool contains(const T& e) const {
-            return std::find(begin(), end(), e) != end();
+        virtual bool contains( const T& e ) const
+        {
+            return std::find( begin(), end(), e ) != end();
         }
 
-        std::size_t indexOf( const T& e ) const {
-            std::size_t index = std::distance( begin() , std::find( begin() , end(), e ) );
+        std::size_t indexOf( const T& e ) const
+        {
+            std::size_t index = std::distance( begin(), std::find( begin(), end(), e ) );
             return index == size() ? -1 : index;
         }
 
         /** Iterator interfaces for an EList<T>. */
-        template <typename ListType >
-        class EListIterator {
+        template <typename ListType>
+        class EListIterator
+        {
         public:
             using iterator_category = std::random_access_iterator_tag;
-            using difference_type   = std::ptrdiff_t;
-            using value_type        = typename ListType::ValueType;
-            using pointer           = typename ListType::ValueType*;
-            using reference         = typename ListType::ValueType&;
-            
+            using difference_type = std::ptrdiff_t;
+            using value_type = typename ListType::ValueType;
+            using pointer = typename ListType::ValueType*;
+            using reference = typename ListType::ValueType&;
+
         public:
             EListIterator( ListType* eList, std::size_t index )
                 : eList_( eList )
-                , index_( index ) {
+                , index_( index )
+            {
             }
 
-            T operator*() const {
+            T operator*() const
+            {
                 return eList_->get( index_ );
             }
 
-            EListIterator& operator--() {
+            EListIterator& operator--()
+            {
                 --index_;
                 return *this;
             }
 
-            EListIterator operator--( int ) {
+            EListIterator operator--( int )
+            {
                 EListIterator old( *this );
-                --(*this);
+                --( *this );
                 return old;
             }
 
-            EListIterator& operator++() {
+            EListIterator& operator++()
+            {
                 ++index_;
                 return *this;
             }
 
-            EListIterator operator++( int ) {
+            EListIterator operator++( int )
+            {
                 EListIterator old( *this );
-                ++(*this);
+                ++( *this );
                 return old;
             }
 
             EListIterator& operator+=( difference_type offset )
             {
                 index_ += offset;
-                return (*this);
+                return ( *this );
             }
 
             EListIterator& operator-=( difference_type offset )
             {
-                return (*this += -offset);
+                return ( *this += -offset );
             }
 
             EListIterator operator+( const difference_type& offset ) const
             {
                 EListIterator tmp = *this;
-                return (tmp += offset);
+                return ( tmp += offset );
             }
 
             EListIterator operator-( const difference_type& rhs ) const
             {
                 EListIterator tmp = *this;
-                return (tmp -= offset);
+                return ( tmp -= offset );
             }
 
             difference_type operator-( const EListIterator& rhs ) const
@@ -128,13 +141,15 @@ namespace ecore {
                 return index_ - rhs.index_;
             }
 
-            bool operator==( const EListIterator& rhs ) const {
+            bool operator==( const EListIterator& rhs ) const
+            {
                 _Compat( rhs );
-                return (index_ == rhs.index_);
+                return ( index_ == rhs.index_ );
             }
 
-            bool operator!=( const EListIterator& rhs ) const {
-                return !(*this == rhs);
+            bool operator!=( const EListIterator& rhs ) const
+            {
+                return !( *this == rhs );
             }
 
             bool operator<( const EListIterator& rhs )
@@ -145,28 +160,31 @@ namespace ecore {
 
             bool operator>( const EListIterator& rhs )
             {
-                return (rhs < *this);
+                return ( rhs < *this );
             }
 
             bool operator<=( const EListIterator& rhs )
             {
-                return (!(rhs < *this));
+                return ( !( rhs < *this ) );
             }
 
             bool operator>=( const EListIterator& rhs )
             {
-                return (!(*this < rhs));
+                return ( !( *this < rhs ) );
             }
 
-            bool hasNext() const {
-                return ((int64_t)index_ < (int64_t)eList_->size() - 1);
+            bool hasNext() const
+            {
+                return ( (int64_t)index_ < (int64_t)eList_->size() - 1 );
             }
 
-            const ListType* getEList() const {
+            const ListType* getEList() const
+            {
                 return eList_;
             }
 
-            std::size_t getIndex() const {
+            std::size_t getIndex() const
+            {
                 return index_;
             }
 
@@ -188,45 +206,50 @@ namespace ecore {
         typedef EListIterator<EList<T>> iterator;
         typedef EListIterator<const EList<T>> const_iterator;
 
-        iterator begin() {
+        iterator begin()
+        {
             return iterator( this, 0 );
         }
 
-        const_iterator begin() const {
+        const_iterator begin() const
+        {
             return const_iterator( this, 0 );
         }
 
-        iterator end() {
+        iterator end()
+        {
             return iterator( this, size() );
         }
 
-        const_iterator end() const {
+        const_iterator end() const
+        {
             return const_iterator( this, size() );
         }
 
-        const_iterator cbegin() const {
+        const_iterator cbegin() const
+        {
             return begin();
         }
 
-        const_iterator cend() const {
+        const_iterator cend() const
+        {
             return end();
         }
 
         /**
          * Allows treating an EList<T> as an EList<Q> (if T can be casted to Q dynamically)
          */
-        template< typename Q >
-        inline std::shared_ptr<EList< Q >> asEListOf()
+        template <typename Q>
+        inline std::shared_ptr<EList<Q>> asEListOf()
         {
             return std::make_shared<detail::DelegateEList<Q, T>>( shared_from_this() );
         }
 
-        template< typename Q >
-        inline std::shared_ptr<const EList< Q >> asEListOf() const
+        template <typename Q>
+        inline std::shared_ptr<const EList<Q>> asEListOf() const
         {
             return std::make_shared<detail::ConstDelegateEList<Q, T>>( shared_from_this() );
         }
-
     };
 
     template <typename T>
@@ -235,7 +258,7 @@ namespace ecore {
     template <typename T>
     bool operator!=( const EList<T>& lhs, const EList<T>& rhs );
 
-}
+} // namespace ecore
 
 #include "ecore/EList.inl"
 

--- a/ecore/lib/src/ecore/ETreeIterator.hpp
+++ b/ecore/lib/src/ecore/ETreeIterator.hpp
@@ -21,8 +21,15 @@ namespace ecore
 {
 
     template <typename T>
-    class ETreeIterator : public std::iterator< std::forward_iterator_tag, T >
+    class ETreeIterator
     {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = typename T;
+        using pointer           = typename T*;
+        using reference         = typename T&;
+
     public:
         explicit ETreeIterator()
         {

--- a/ecore/lib/src/ecore/EcoreUtils.hpp
+++ b/ecore/lib/src/ecore/EcoreUtils.hpp
@@ -13,8 +13,8 @@
 #include "ecore/Exports.hpp"
 #include "ecore/Uri.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
 
 namespace ecore
 {
@@ -24,7 +24,6 @@ namespace ecore
     class EDataType;
     class EResource;
     class EResourceSet;
-
 
     class ECORE_API EcoreUtils
     {
@@ -37,27 +36,28 @@ namespace ecore
 
         static Any createFromString( const std::shared_ptr<EDataType>& eDataType, const std::string& literal );
 
-        static URI getURI(const std::shared_ptr<EObject>& eObject);
+        static URI getURI( const std::shared_ptr<EObject>& eObject );
 
-        static std::shared_ptr<EObject> getEObject(const std::shared_ptr<EObject>& rootEObject, const std::string& relativeFragmentPath);
-        
-        static std::shared_ptr<EObject> resolve(const std::shared_ptr<EObject>& proxy, const std::shared_ptr<EObject>& context );
+        static std::shared_ptr<EObject> getEObject( const std::shared_ptr<EObject>& rootEObject, const std::string& relativeFragmentPath );
+
+        static std::shared_ptr<EObject> resolve( const std::shared_ptr<EObject>& proxy, const std::shared_ptr<EObject>& context );
 
         static std::shared_ptr<EObject> resolve( const std::shared_ptr<EObject>& proxy, const std::shared_ptr<EResource>& context );
 
         static std::shared_ptr<EObject> resolve( const std::shared_ptr<EObject>& proxy, const std::shared_ptr<EResourceSet>& context );
 
         static bool isAncestor( const std::shared_ptr<EObject>& ancestor, const std::shared_ptr<EObject>& object );
-        
-        // Determines if the class represented by eSuper object is either the same as, or is a superclass of, the class represented by the specified eClass parameter. 
-        // It returns true if so; otherwise it returns false.
+
+        // Determines if the class represented by eSuper object is either the same as, or is a superclass of, the class represented by the
+        // specified eClass parameter. It returns true if so; otherwise it returns false.
         static bool isAssignableFrom( const std::shared_ptr<EClass>& eSuper, const std::shared_ptr<EClass>& eClass );
 
     private:
-
-        static std::string getRelativeURIFragmentPath(const std::shared_ptr<EObject>& ancestor, const std::shared_ptr<EObject>& descendant, bool resolve);
+        static std::string getRelativeURIFragmentPath( const std::shared_ptr<EObject>& ancestor,
+                                                       const std::shared_ptr<EObject>& descendant,
+                                                       bool resolve );
     };
 
-} // namespace ecore::impl
+} // namespace ecore
 
 #endif

--- a/ecore/lib/src/ecore/ext/EClassBaseExt.inl
+++ b/ecore/lib/src/ecore/ext/EClassBaseExt.inl
@@ -11,18 +11,18 @@
 #error This file may only be included from EClassBaseExt.hpp
 #endif
 
+#include "ecore/AnyCast.hpp"
 #include "ecore/EAdapter.hpp"
 #include "ecore/EAttribute.hpp"
 #include "ecore/EOperation.hpp"
 #include "ecore/EReference.hpp"
 #include "ecore/EcorePackage.hpp"
+#include "ecore/ext/EClassInternal.hpp"
 #include "ecore/impl/AbstractAdapter.hpp"
 #include "ecore/impl/EOperationImpl.hpp"
 #include "ecore/impl/EOperationInternal.hpp"
 #include "ecore/impl/EStructuralFeatureImpl.hpp"
 #include "ecore/impl/ImmutableHashEList.hpp"
-#include "ecore/ext/EClassInternal.hpp"
-
 
 #include "EClassBaseExt.hpp"
 #include <algorithm>
@@ -65,7 +65,7 @@ namespace ecore::ext
                         Any oldValue = notification->getOldValue();
                         if( !oldValue.empty() )
                         {
-                            auto eClass = anyCast<std::shared_ptr<EClass>>( oldValue );
+                            auto eClass = anyObjectCast<std::shared_ptr<EClass>>( oldValue );
                             auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
                             auto& subClasses = eClassImpl->eSuperAdapter_->getSubClasses();
                             auto it = std::find_if(
@@ -76,7 +76,7 @@ namespace ecore::ext
                         Any newValue = notification->getNewValue();
                         if( !newValue.empty() )
                         {
-                            auto eClass = anyCast<std::shared_ptr<EClass>>( newValue );
+                            auto eClass = anyObjectCast<std::shared_ptr<EClass>>( newValue );
                             auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
                             auto& subClasses = eClassImpl->eSuperAdapter_->getSubClasses();
                             subClasses.push_back( eNotifier );
@@ -88,7 +88,7 @@ namespace ecore::ext
                         Any newValue = notification->getNewValue();
                         if( !newValue.empty() )
                         {
-                            auto eClass = anyCast<std::shared_ptr<EClass>>( newValue );
+                            auto eClass = anyObjectCast<std::shared_ptr<EClass>>( newValue );
                             auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
                             auto& subClasses = eClassImpl->eSuperAdapter_->getSubClasses();
                             subClasses.push_back( eNotifier );
@@ -100,7 +100,7 @@ namespace ecore::ext
                         Any newValue = notification->getNewValue();
                         if( !newValue.empty() )
                         {
-                            auto eCollection = anyCast<std::shared_ptr<EList<std::shared_ptr<EClass>>>>( newValue );
+                            auto eCollection = anyListCast<std::shared_ptr<EClass>>( newValue );
                             for( const auto& eClass : *eCollection )
                             {
                                 auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
@@ -115,7 +115,7 @@ namespace ecore::ext
                         Any oldValue = notification->getOldValue();
                         if( !oldValue.empty() )
                         {
-                            auto eClass = anyCast<std::shared_ptr<EClass>>( oldValue );
+                            auto eClass = anyObjectCast<std::shared_ptr<EClass>>( oldValue );
                             auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
                             auto& subClasses = eClassImpl->eSuperAdapter_->getSubClasses();
                             auto it = std::find_if(
@@ -130,7 +130,7 @@ namespace ecore::ext
                         Any oldValue = notification->getOldValue();
                         if( !oldValue.empty() )
                         {
-                            auto eCollection = anyCast<std::shared_ptr<EList<std::shared_ptr<EClass>>>>( oldValue );
+                            auto eCollection = anyListCast<std::shared_ptr<EClass>>( oldValue );
                             for( const auto& eClass : *eCollection )
                             {
                                 auto eClassImpl = std::static_pointer_cast<EClassBaseExt>( eClass );
@@ -563,8 +563,7 @@ namespace ecore::ext
 
         inline EClassBaseExt<I...>& getObject()
         {
-            return static_cast<EClassBaseExt<I...>&>(
-                ecore::impl::EClassBase<I...>::EObjectInternalAdapter<typename U>::getObject() );
+            return static_cast<EClassBaseExt<I...>&>( ecore::impl::EClassBase<I...>::EObjectInternalAdapter<typename U>::getObject() );
         }
 
         inline const EClassBaseExt<I...>& getObject() const

--- a/ecore/lib/src/ecore/impl/AbstractAdapter.cpp
+++ b/ecore/lib/src/ecore/impl/AbstractAdapter.cpp
@@ -15,3 +15,9 @@ void AbstractAdapter::setTarget( const std::shared_ptr<ENotifier>& notifier )
 {
     target_ = notifier;
 }
+
+void AbstractAdapter::unsetTarget( const std::shared_ptr<ENotifier>& target )
+{
+    if( target == target_.lock() )
+        setTarget( nullptr );
+}

--- a/ecore/lib/src/ecore/impl/AbstractAdapter.hpp
+++ b/ecore/lib/src/ecore/impl/AbstractAdapter.hpp
@@ -29,6 +29,8 @@ namespace ecore::impl
 
         virtual void setTarget( const std::shared_ptr<ENotifier>& target );
 
+        virtual void unsetTarget( const std::shared_ptr<ENotifier>& target );
+
     protected:
         std::weak_ptr<ENotifier> target_;
     };

--- a/ecore/lib/src/ecore/impl/BasicNotifier.hpp
+++ b/ecore/lib/src/ecore/impl/BasicNotifier.hpp
@@ -78,9 +78,10 @@ namespace ecore::impl
 
             virtual void didRemove( std::size_t pos, const ValueType& adapter ) override
             {
-                //  notify removing adapter
                 auto notifier = notifier_.thisPtr_.lock();
                 auto eAdapter = const_cast<EAdapter*>( adapter );
+                
+                //  notify removing adapter
                 if( notifier_.eDeliver_ )
                     eAdapter->notifyChanged(
                         std::make_shared<Notification>( *this, Notification::REMOVING_ADAPTER, eAdapter, NO_VALUE, pos ) );

--- a/ecore/lib/src/ecore/impl/BasicNotifier.hpp
+++ b/ecore/lib/src/ecore/impl/BasicNotifier.hpp
@@ -10,9 +10,9 @@
 #ifndef ECORE_BASIC_NOTIFIER_HPP_
 #define ECORE_BASIC_NOTIFIER_HPP_
 
-#include <memory>
 #include "ecore/EAdapter.hpp"
 #include "ecore/impl/BasicEList.hpp"
+#include <memory>
 
 namespace ecore::impl
 {
@@ -32,7 +32,7 @@ namespace ecore::impl
         {
             return eDeliver_;
         }
-        
+
         virtual void eSetDeliver( bool deliver )
         {
             eDeliver_ = deliver;
@@ -45,7 +45,7 @@ namespace ecore::impl
         }
 
         bool eNotificationRequired() const
-        { 
+        {
             return eDeliver_ && eAdapters_->size() > 0;
         }
 
@@ -53,35 +53,70 @@ namespace ecore::impl
         {
             thisPtr_ = thisPtr;
         }
-        
+
         inline std::shared_ptr<BasicNotifier> getThisPtr() const
         {
             return thisPtr_.lock();
         }
 
     private:
-
         class AdapterList : public BasicEList<EAdapter*>
         {
         public:
             AdapterList( BasicNotifier& notifier )
                 : notifier_( notifier )
             {
-
             }
 
         protected:
-            
             virtual void didAdd( std::size_t pos, const ValueType& adapter ) override
             {
-                std::shared_ptr<ENotifier> notifier = notifier_.thisPtr_.lock();
-                const_cast<EAdapter*>( adapter )->setTarget( notifier );
+                auto notifier = notifier_.thisPtr_.lock();
+                auto eAdapter = const_cast<EAdapter*>( adapter );
+                eAdapter->setTarget( notifier );
             }
 
             virtual void didRemove( std::size_t pos, const ValueType& adapter ) override
             {
-                const_cast<EAdapter*>( adapter )->setTarget( nullptr );
+                //  notify removing adapter
+                auto notifier = notifier_.thisPtr_.lock();
+                auto eAdapter = const_cast<EAdapter*>( adapter );
+                if( notifier_.eDeliver_ )
+                    eAdapter->notifyChanged(
+                        std::make_shared<Notification>( *this, Notification::REMOVING_ADAPTER, eAdapter, NO_VALUE, pos ) );
+
+                // unset target
+                eAdapter->unsetTarget( notifier );
             }
+
+        private:
+            class Notification : public AbstractNotification
+            {
+            public:
+                Notification( AdapterList& list, EventType type, const Any& oldValue, const Any& newValue, std::size_t position = NO_INDEX )
+                    : AbstractNotification( type, oldValue, newValue, position )
+                    , list_( list )
+                {
+                }
+                virtual std::shared_ptr<ENotifier> getNotifier() const
+                {
+                    auto& notifier = list_.notifier_;
+                    return notifier.thisPtr_.lock();
+                }
+
+                virtual int getFeatureID() const
+                {
+                    return -1;
+                }
+
+                virtual std::shared_ptr<EStructuralFeature> getFeature() const
+                {
+                    return nullptr;
+                }
+
+            private:
+                AdapterList& list_;
+            };
 
         private:
             BasicNotifier& notifier_;
@@ -89,11 +124,9 @@ namespace ecore::impl
 
     protected:
         std::weak_ptr<BasicNotifier> thisPtr_;
-        std::unique_ptr<EList<EAdapter*>> eAdapters_{new AdapterList(*this)};
-        bool eDeliver_{ true };
+        std::unique_ptr<EList<EAdapter*>> eAdapters_{new AdapterList( *this )};
+        bool eDeliver_{true};
     };
-}
-
-
+} // namespace ecore::impl
 
 #endif /* ECORE_ABSTRACT_NOTIFIER_HPP_ */

--- a/ecore/lib/src/ecore/impl/ImmutableEList.hpp
+++ b/ecore/lib/src/ecore/impl/ImmutableEList.hpp
@@ -10,6 +10,8 @@
 #ifndef ECORE_IMMUTABLE_ELIST_HPP_
 #define ECORE_IMMUTABLE_ELIST_HPP_
 
+#include "ecore/EList.hpp"
+
 #include <vector>
 
 namespace ecore::impl

--- a/ecore/tests/CMakeFiles.txt
+++ b/ecore/tests/CMakeFiles.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
     src/BasicNotifierTests.cpp
     src/DiamondVsMixinsTests.cpp
     src/DynamicEObjectTests.cpp
+    src/EContentAdapterTests.cpp
     src/EcoreFactoryTests.cpp
     src/EcorePackageTests.cpp
     src/EcoreUtilsTests.cpp

--- a/ecore/tests/src/BasicNotifierTests.cpp
+++ b/ecore/tests/src/BasicNotifierTests.cpp
@@ -11,7 +11,7 @@ using namespace ecore::tests;
 
 using Notifier = BasicNotifier<ENotifier>;
 
-BOOST_AUTO_TEST_SUITE( NotifierTests )
+BOOST_AUTO_TEST_SUITE( BasicNotifierTests )
 
 BOOST_AUTO_TEST_CASE( Constructor )
 {
@@ -32,9 +32,18 @@ BOOST_AUTO_TEST_CASE( Target )
     auto notifier = std::make_shared<Notifier>();
     notifier->setThisPtr( notifier );
     auto adapter = std::make_unique<MockAdapter>();
+    
     MOCK_EXPECT( adapter->setTarget ).with( notifier ).once();
     notifier->eAdapters().add( adapter.get() );
-    MOCK_EXPECT( adapter->setTarget ).with( nullptr ).once();
+
+    MOCK_EXPECT( adapter->notifyChanged )
+        .with( [&]( const std::shared_ptr<ENotification>& n ) {
+            return n->getNotifier() == notifier && n->getFeatureID() == -1
+                   && n->getOldValue() == static_cast<EAdapter*>(adapter.get()) && n->getNewValue() == NO_VALUE
+                   && n->getPosition() == 0;
+        } )
+        .once();
+    MOCK_EXPECT( adapter->unsetTarget ).with( notifier ).once();
     notifier->eAdapters().remove( adapter.get() );
 }
 

--- a/ecore/tests/src/EAttributeTests.cpp
+++ b/ecore/tests/src/EAttributeTests.cpp
@@ -27,7 +27,8 @@ namespace
 
         ~AttributeNotificationsFixture()
         {
-            MOCK_EXPECT( eAdapter->setTarget ).with( nullptr ).once();
+            MOCK_EXPECT( eAdapter->unsetTarget ).with( eAttribute ).once();
+            eAttribute->eSetDeliver( false );
             eAttribute->eAdapters().remove( eAdapter.get() );
         }
 

--- a/ecore/tests/src/EContentAdapterTests.cpp
+++ b/ecore/tests/src/EContentAdapterTests.cpp
@@ -1,0 +1,233 @@
+#include <boost/test/unit_test.hpp>
+
+#include "ecore/EContentAdapter.hpp"
+#include "ecore/Stream.hpp"
+#include "ecore/impl/ImmutableEList.hpp"
+#include "ecore/tests/MockList.hpp"
+#include "ecore/tests/MockNotification.hpp"
+#include "ecore/tests/MockObject.hpp"
+
+#include <chrono>
+#include <random>
+
+using namespace ecore;
+using namespace ecore::impl;
+using namespace ecore::tests;
+
+namespace
+{
+    std::default_random_engine generator;
+    constexpr int nb_children = 10;
+    constexpr int nb_objects = 2;
+} // namespace
+
+BOOST_AUTO_TEST_SUITE( EContentAdapterTests )
+
+BOOST_AUTO_TEST_CASE( SetTarget )
+{
+    EContentAdapter adapter;
+
+    // create mock children for a mock object
+    
+    std::uniform_int_distribution<int> d( 0, nb_children );
+    auto nb = d( generator );
+    std::vector<std::shared_ptr<EObject>> vchildren;
+    for( int i = 0; i < nb; ++i )
+    {
+        auto mockObject = std::make_shared<MockObject>();
+        auto mockAdapters = std::make_shared<MockList<EAdapter*>>();
+        MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
+        MOCK_EXPECT( mockAdapters->contains ).once().with( &adapter ).returns( false );
+        MOCK_EXPECT( mockAdapters->add ).once().with( &adapter ).returns( true );
+        MOCK_EXPECT( mockAdapters->removeObject ).once().with( &adapter ).returns( true );
+        vchildren.push_back( mockObject );
+    }
+    auto mockChildren = std::make_shared<ImmutableEList<std::shared_ptr<EObject>>>( std::move( vchildren ) );
+
+    // create mock object
+    auto mockObject = std::make_shared<MockObject>();
+    auto mockAdapters = std::make_shared<MockList<EAdapter*>>();
+    MOCK_EXPECT( mockObject->eContents ).returns( mockChildren->asEListOf<std::shared_ptr<EObject>>() );
+    MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
+
+    // set adapter target -> this should recursively register adapter on all object children
+    adapter.setTarget( mockObject );
+
+    // unset adapter target -> this should recursively unregister adapter on all object children
+    adapter.setTarget( nullptr );
+}
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_Resolve )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockOldObject = std::make_shared<MockObject>();
+    auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
+
+    MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
+    MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( false );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::RESOLVE );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( std::static_pointer_cast<EObject>( mockOldObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_Resolve_Contains )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockOldObject = std::make_shared<MockObject>();
+    auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
+    auto mockNewObject = std::make_shared<MockObject>();
+    auto mockNewAdapters = std::make_shared<MockList<EAdapter*>>();
+
+    MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
+    MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( true );
+    MOCK_EXPECT( mockOldAdapters->removeObject ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( mockNewObject->eAdapters ).returns( *mockNewAdapters );
+    MOCK_EXPECT( mockNewAdapters->contains ).with( &adapter ).returns( false );
+    MOCK_EXPECT( mockNewAdapters->add ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::RESOLVE );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( std::static_pointer_cast<EObject>( mockOldObject ) ) );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any( std::static_pointer_cast<EObject>( mockNewObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_UnSet )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockOldObject = std::make_shared<MockObject>();
+    auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
+    auto mockNewObject = std::make_shared<MockObject>();
+    auto mockNewAdapters = std::make_shared<MockList<EAdapter*>>();
+
+    MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
+    MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( true );
+    MOCK_EXPECT( mockOldAdapters->removeObject ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( mockNewObject->eAdapters ).returns( *mockNewAdapters );
+    MOCK_EXPECT( mockNewAdapters->contains ).with( &adapter ).returns( false );
+    MOCK_EXPECT( mockNewAdapters->add ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::SET );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( std::static_pointer_cast<EObject>( mockOldObject ) ) );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any( std::static_pointer_cast<EObject>( mockNewObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_Set )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockOldObject = std::make_shared<MockObject>();
+    auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
+    auto mockNewObject = std::make_shared<MockObject>();
+    auto mockNewAdapters = std::make_shared<MockList<EAdapter*>>();
+
+    MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
+    MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( true );
+    MOCK_EXPECT( mockOldAdapters->removeObject ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( mockNewObject->eAdapters ).returns( *mockNewAdapters );
+    MOCK_EXPECT( mockNewAdapters->contains ).with( &adapter ).returns( false );
+    MOCK_EXPECT( mockNewAdapters->add ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::SET );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( std::static_pointer_cast<EObject>( mockOldObject ) ) );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any( std::static_pointer_cast<EObject>( mockNewObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_Add )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockNewObject = std::make_shared<MockObject>();
+    auto mockNewAdapters = std::make_shared<MockList<EAdapter*>>();
+
+    MOCK_EXPECT( mockNewObject->eAdapters ).returns( *mockNewAdapters );
+    MOCK_EXPECT( mockNewAdapters->contains ).with( &adapter ).returns( false );
+    MOCK_EXPECT( mockNewAdapters->add ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::ADD );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any( std::static_pointer_cast<EObject>( mockNewObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_AddMany )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    
+    std::vector<std::shared_ptr<EObject>> mockObjects;
+    std::uniform_int_distribution<int> d( 1, nb_objects );
+    auto nb = d( generator );
+    for( int i = 0; i < nb; ++i )
+    {
+        auto mockObject = std::make_shared<MockObject>();
+        auto mockAdapters = std::make_shared<MockList<EAdapter*>>();
+        MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
+        MOCK_EXPECT( mockAdapters->contains ).with( &adapter ).returns( false );
+        MOCK_EXPECT( mockAdapters->add ).with( &adapter ).returns( true );
+        mockObjects.push_back( mockObject );
+    }
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::ADD_MANY );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any( mockObjects ) );
+
+    adapter.notifyChanged( notification );
+}
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_Remove )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+    auto mockOldObject = std::make_shared<MockObject>();
+    auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
+   
+    MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
+    MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( true );
+    MOCK_EXPECT( mockOldAdapters->removeObject ).with( &adapter ).returns( true );
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::REMOVE );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( std::static_pointer_cast<EObject>( mockOldObject ) ) );
+
+    adapter.notifyChanged( notification );
+}
+
+BOOST_AUTO_TEST_CASE( NotifyChanged_RemoveMany )
+{
+    EContentAdapter adapter;
+    auto notification = std::make_shared<MockNotification>();
+
+    std::vector<std::shared_ptr<EObject>> mockObjects;
+    std::uniform_int_distribution<int> d( 1, nb_objects );
+    auto nb = d( generator );
+    for( int i = 0; i < nb; ++i )
+    {
+        auto mockObject = std::make_shared<MockObject>();
+        auto mockAdapters = std::make_shared<MockList<EAdapter*>>();
+        MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
+        MOCK_EXPECT( mockAdapters->contains ).with( &adapter ).returns( false );
+        MOCK_EXPECT( mockAdapters->removeObject ).with( &adapter ).returns( true );
+        mockObjects.push_back( mockObject );
+    }
+
+    MOCK_EXPECT( notification->getEventType ).returns( ENotification::REMOVE_MANY );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any( mockObjects ) );
+
+    adapter.notifyChanged( notification );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/ecore/tests/src/EContentAdapterTests.cpp
+++ b/ecore/tests/src/EContentAdapterTests.cpp
@@ -49,10 +49,8 @@ BOOST_AUTO_TEST_CASE( SetTarget )
 
     // create mock object
     auto mockObject = std::make_shared<MockObject>();
-    auto mockAdapters = std::make_shared<MockList<EAdapter*>>();
     MOCK_EXPECT( mockObject->eContents ).returns( mockChildren->asEListOf<std::shared_ptr<EObject>>() );
-    MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
-
+    
     // set adapter target -> this should recursively register adapter on all object children
     adapter.setTarget( mockObject );
 
@@ -124,7 +122,6 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_UnSet )
     auto mockNotification = std::make_shared<MockNotification>();
     auto mockReference = std::make_shared<MockReference>();
     auto mockOldObject = std::make_shared<MockObject>();
-    auto mockOldObjectInternal = std::make_shared<MockObjectInternal>();
     auto mockOldAdapters = std::make_shared<MockList<EAdapter*>>();
     auto mockNewObject = std::make_shared<MockObject>();
     auto mockNewAdapters = std::make_shared<MockList<EAdapter*>>();
@@ -132,8 +129,6 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_UnSet )
     MOCK_EXPECT( mockReference->isContainment ).once().returns( true );
 
     MOCK_EXPECT( mockOldObject->eAdapters ).returns( *mockOldAdapters );
-    MOCK_EXPECT( mockOldObject->getInternal ).returns( *mockOldObjectInternal );
-    MOCK_EXPECT( mockOldObjectInternal->eInternalContainer ).returns( std::shared_ptr<EObject>() );
     MOCK_EXPECT( mockOldAdapters->contains ).with( &adapter ).returns( true );
     MOCK_EXPECT( mockOldAdapters->removeObject ).with( &adapter ).returns( true );
     

--- a/ecore/tests/src/EContentAdapterTests.cpp
+++ b/ecore/tests/src/EContentAdapterTests.cpp
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_AddMany )
     EContentAdapter adapter;
     auto notification = std::make_shared<MockNotification>();
     
-    std::vector<std::shared_ptr<EObject>> mockObjects;
+    std::vector<Any> mockObjects;
     std::uniform_int_distribution<int> d( 1, nb_objects );
     auto nb = d( generator );
     for( int i = 0; i < nb; ++i )
@@ -180,11 +180,11 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_AddMany )
         MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
         MOCK_EXPECT( mockAdapters->contains ).with( &adapter ).returns( false );
         MOCK_EXPECT( mockAdapters->add ).with( &adapter ).returns( true );
-        mockObjects.push_back( mockObject );
+        mockObjects.push_back( std::static_pointer_cast<EObject>(mockObject) );
     }
 
     MOCK_EXPECT( notification->getEventType ).returns( ENotification::ADD_MANY );
-    MOCK_EXPECT( notification->getNewValue ).returns( Any( mockObjects ) );
+    MOCK_EXPECT( notification->getNewValue ).returns( Any(mockObjects) );
 
     adapter.notifyChanged( notification );
 }
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_RemoveMany )
     EContentAdapter adapter;
     auto notification = std::make_shared<MockNotification>();
 
-    std::vector<std::shared_ptr<EObject>> mockObjects;
+    std::vector<Any> mockObjects;
     std::uniform_int_distribution<int> d( 1, nb_objects );
     auto nb = d( generator );
     for( int i = 0; i < nb; ++i )
@@ -221,11 +221,11 @@ BOOST_AUTO_TEST_CASE( NotifyChanged_RemoveMany )
         MOCK_EXPECT( mockObject->eAdapters ).returns( *mockAdapters );
         MOCK_EXPECT( mockAdapters->contains ).with( &adapter ).returns( false );
         MOCK_EXPECT( mockAdapters->removeObject ).with( &adapter ).returns( true );
-        mockObjects.push_back( mockObject );
+        mockObjects.push_back( std::static_pointer_cast<EObject>(mockObject) );
     }
 
     MOCK_EXPECT( notification->getEventType ).returns( ENotification::REMOVE_MANY );
-    MOCK_EXPECT( notification->getOldValue ).returns( Any( mockObjects ) );
+    MOCK_EXPECT( notification->getOldValue ).returns( Any(mockObjects) );
 
     adapter.notifyChanged( notification );
 }

--- a/ecore/tests/src/EContentAdapterTests.cpp
+++ b/ecore/tests/src/EContentAdapterTests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE( SetTarget )
     adapter.setTarget( mockObject );
 
     // unset adapter target -> this should recursively unregister adapter on all object children
-    adapter.setTarget( nullptr );
+    adapter.unsetTarget( mockObject );
 }
 
 BOOST_AUTO_TEST_CASE( NotifyChanged_Attribute )

--- a/ecore/tests/src/ResourceTests.cpp
+++ b/ecore/tests/src/ResourceTests.cpp
@@ -46,7 +46,8 @@ namespace
 
         ~NotificationsFixture()
         {
-            MOCK_EXPECT( eAdapter->setTarget ).with( nullptr ).once();
+            MOCK_EXPECT( eAdapter->unsetTarget ).with( resource ).once();
+            resource->eSetDeliver( false );
             resource->eAdapters().remove( eAdapter.get() );
         }
 

--- a/ecore/tests/src/ecore/tests/MockAdapter.hpp
+++ b/ecore/tests/src/ecore/tests/MockAdapter.hpp
@@ -20,6 +20,7 @@ namespace ecore::tests
         MOCK_METHOD( notifyChanged, 1 );
         MOCK_METHOD( getTarget , 0 );
         MOCK_METHOD( setTarget, 1 );
+        MOCK_METHOD( unsetTarget, 1 );
     };
 }
 

--- a/ecore/tests/src/ecore/tests/MockList.hpp
+++ b/ecore/tests/src/ecore/tests/MockList.hpp
@@ -28,6 +28,7 @@ namespace ecore::tests
         MOCK_METHOD_TPL( set, 2, T( std::size_t, const T& ));
         MOCK_METHOD_TPL( remove, 1, T( std::size_t ), removeIndex );
         MOCK_METHOD_TPL( remove, 1, bool( const T& ), removeObject );
+        MOCK_CONST_METHOD_TPL( contains, 1, bool(const T&) );
         MOCK_CONST_METHOD_TPL( size, 0, std::size_t());
         MOCK_METHOD_TPL( clear, 0, void());
         MOCK_CONST_METHOD_TPL( empty, 0, bool());

--- a/library/tests/CMakeFiles.txt
+++ b/library/tests/CMakeFiles.txt
@@ -2,7 +2,12 @@
 
 set(SOURCE_FILES
     src/main.cpp
+    src/ContentAdapterTests.cpp
+    src/LibraryFactory.cpp
     src/SerializationTests.cpp
     src/MetaModelTests.cpp
 )
 
+set(HEADER_FILES
+    src/LibraryFactory.hpp
+)

--- a/library/tests/src/ContentAdapterTests.cpp
+++ b/library/tests/src/ContentAdapterTests.cpp
@@ -53,8 +53,8 @@ BOOST_AUTO_TEST_CASE( DeepChanged )
     l->eAdapters().add( &mockAdapter );
 
     MOCK_EXPECT( mockAdapter.changed ).with( [=]( const std::shared_ptr<ENotification>& n ) {
-        return n->getNotifier() == e && n->getFeatureID() == LibraryPackage::EMPLOYEE__FIRST_NAME && n->getOldValue() == "First Name 0"
-               && n->getNewValue() == "test" && n->getPosition() == -1;
+        return n->getNotifier() == e && n->getFeatureID() == LibraryPackage::EMPLOYEE__FIRST_NAME
+               && n->getOldValue() == std::string( "First Name 0" ) && n->getNewValue() == std::string( "test" ) && n->getPosition() == -1;
     } );
 
     e->setFirstName( "test" );

--- a/library/tests/src/ContentAdapterTests.cpp
+++ b/library/tests/src/ContentAdapterTests.cpp
@@ -1,0 +1,63 @@
+#include <boost/test/unit_test.hpp>
+#include <turtle/mock.hpp>
+
+#include "LibraryFactory.hpp"
+#include "ecore/EContentAdapter.hpp"
+#include "ecore/ENotification.hpp"
+#include "library/Employee.hpp"
+#include "library/LibraryFactory.hpp"
+#include "library/LibraryPackage.hpp"
+
+using namespace ecore;
+using namespace library;
+using namespace library::tests;
+
+namespace
+{
+    class MockContentAdapter : public EContentAdapter
+    {
+    public:
+        virtual void notifyChanged( const std::shared_ptr<ENotification>& notification )
+        {
+            changed( notification );
+            EContentAdapter::notifyChanged( notification );
+        }
+
+        MOCK_FUNCTOR( changed, void( const std::shared_ptr<ENotification>& ) );
+    };
+} // namespace
+
+BOOST_AUTO_TEST_SUITE( ContentAdapterTests )
+
+BOOST_AUTO_TEST_CASE( TopChanged )
+{
+    auto l = library::tests::LibraryFactory::createLibrary( 2, 5, 20, 5 );
+    auto e = library::LibraryFactory::eInstance()->createEmployee();
+
+    MockContentAdapter mockAdapter;
+    l->eAdapters().add( &mockAdapter );
+
+    MOCK_EXPECT( mockAdapter.changed ).once().with( [=]( const std::shared_ptr<ENotification>& n ) {
+        return n->getNotifier() == l && n->getFeatureID() == LibraryPackage::LIBRARY__EMPLOYEES && n->getOldValue() == NO_VALUE
+               && n->getNewValue() == std::static_pointer_cast<EObject>( e ) && n->getPosition() == 2;
+    } );
+    l->getEmployees()->add( e );
+}
+
+BOOST_AUTO_TEST_CASE( DeepChanged )
+{
+    auto l = library::tests::LibraryFactory::createLibrary( 2, 5, 20, 5 );
+    auto e = l->getEmployees()->get( 0 );
+
+    MockContentAdapter mockAdapter;
+    l->eAdapters().add( &mockAdapter );
+
+    MOCK_EXPECT( mockAdapter.changed ).with( [=]( const std::shared_ptr<ENotification>& n ) {
+        return n->getNotifier() == e && n->getFeatureID() == LibraryPackage::EMPLOYEE__FIRST_NAME && n->getOldValue() == "First Name 0"
+               && n->getNewValue() == "test" && n->getPosition() == -1;
+    } );
+
+    e->setFirstName( "test" );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/library/tests/src/LibraryFactory.cpp
+++ b/library/tests/src/LibraryFactory.cpp
@@ -1,0 +1,142 @@
+#include "LibraryFactory.hpp"
+#include "library/Book.hpp"
+#include "library/Borrower.hpp"
+#include "library/Employee.hpp"
+#include "library/Library.hpp"
+#include "library/LibraryFactory.hpp"
+#include "library/LibraryPackage.hpp"
+#include "library/Writer.hpp"
+
+#include <chrono>
+#include <random>
+#include <stack>
+
+using namespace library;
+using namespace library::tests;
+
+namespace
+{
+    template <class TimePoint>
+    class uniform_time_distribution
+    {
+    public:
+        uniform_time_distribution( TimePoint start, TimePoint end )
+            : m_start( start )
+            , m_end( end )
+            , m_seconds( std::chrono::duration_cast<std::chrono::seconds>( end - start ) )
+        {
+        }
+
+        template <class Generator>
+        TimePoint operator()( Generator&& g )
+        {
+            std::uniform_int_distribution<std::chrono::seconds::rep> d( 0, m_seconds.count() );
+
+            return m_start + std::chrono::seconds( d( g ) );
+        }
+
+    private:
+        TimePoint m_start;
+        TimePoint m_end;
+        std::chrono::seconds m_seconds;
+    };
+
+    template <class TimePoint>
+    TimePoint randomTime( TimePoint start, TimePoint end )
+    {
+        static std::random_device rd;
+        static std::mt19937 gen( rd() );
+        uniform_time_distribution<TimePoint> t( start, end );
+        return t( gen );
+    }
+
+} // namespace
+
+std::shared_ptr<Library> library::tests::LibraryFactory::createLibrary( int nb_employees, int nb_writers, int nb_books, int nb_borrowers )
+{
+    auto lf = library::LibraryFactory::eInstance();
+    auto lp = library::LibraryPackage::eInstance();
+
+    auto l = lf->createLibrary();
+    l->setName( "My Library" );
+    l->setAddress( "My Library Adress" );
+
+    std::default_random_engine generator;
+
+    // employees
+    auto employees = l->getEmployees();
+    for( int i = 0; i < nb_employees; ++i )
+    {
+        auto ndx = std::to_string( i );
+        auto e = lf->createEmployee();
+        e->setAddress( "Adress " + ndx );
+        e->setFirstName( "First Name " + ndx );
+        e->setLastName( "Last Name " + ndx );
+
+        if( !employees->empty() )
+        {
+            std::uniform_int_distribution<int> d( 0, static_cast<int>( employees->size() ) - 1 );
+            auto ndx = d( generator );
+            e->setManager( employees->get( ndx ) );
+        }
+
+        employees->add( e );
+    }
+
+    // writers
+    for( int i = 0; i < nb_writers; ++i )
+    {
+        auto w = lf->createWriter();
+        auto ndx = std::to_string( i );
+        w->setAddress( "Adress " + ndx );
+        w->setFirstName( "First Name " + ndx );
+        w->setLastName( "Last Name " + ndx );
+
+        l->getWriters()->add( w );
+    }
+
+    // books
+    std::uniform_int_distribution<int> book_author_distibution( 0, nb_writers > 0 ? nb_writers - 1 : 0 );
+    std::uniform_int_distribution<int> book_category_distibution( 0, 2 );
+    std::uniform_int_distribution<int> book_copies_distibution( 1, 5 );
+    std::uniform_int_distribution<int> book_pages_distibution( 1, 500 );
+    auto start_date = std::chrono::system_clock::from_time_t( std::time_t( 0 ) );
+    auto end_date = std::chrono::system_clock::now();
+    for( int i = 0; i < nb_books; ++i )
+    {
+        auto b = lf->createBook();
+        b->setCategory( BookCategory( book_category_distibution( generator ) ) );
+        b->setCopies( book_copies_distibution( generator ) );
+        b->setPages( book_pages_distibution( generator ) );
+        b->setPublicationDate( std::chrono::system_clock::to_time_t( randomTime( start_date, end_date ) ) );
+        b->setTitle( "Title " + std::to_string( i ) );
+
+        if ( nb_writers > 0 )
+        {
+            auto authorNdx = book_author_distibution( generator );
+            auto a = l->getWriters()->get( authorNdx );
+            b->setAuthor( a );
+        }
+
+        l->getBooks()->add( b );
+    }
+
+    // borrowers
+    std::uniform_int_distribution<int> borrower_book_distibution( 0, nb_borrowers > 0 ? nb_borrowers - 1 : 0 );
+    for( int i = 0; i < nb_borrowers; ++i )
+    {
+        auto b = lf->createBorrower();
+        auto ndx = std::to_string( i );
+        b->setAddress( "Adress " + ndx );
+        b->setFirstName( "First Name " + ndx );
+        b->setLastName( "Last Name " + ndx );
+
+        if ( nb_books > 0 )
+        {
+            auto bookNdx = borrower_book_distibution( generator );
+            auto book = l->getBooks()->get( bookNdx );
+            b->getBorrowed()->add( book );
+        }
+    }
+    return l;
+}

--- a/library/tests/src/LibraryFactory.hpp
+++ b/library/tests/src/LibraryFactory.hpp
@@ -1,0 +1,25 @@
+// *****************************************************************************
+//
+// This file is part of a MASA library or program.
+// Refer to the included end-user license agreement for restrictions.
+//
+// Copyright (c) 2020 MASA Group
+//
+// *****************************************************************************
+
+#ifndef LIBRARY_TESTS_LIBRARYFACTORY_CPP
+#define LIBRARY_TESTS_LIBRARYFACTORY_CPP
+
+#include "library/Library.hpp"
+
+namespace library::tests
+{
+    class LibraryFactory
+    {
+    public:
+        static std::shared_ptr<Library> createLibrary( int nb_employees, int nb_writers, int nb_books, int nb_borrowers );
+    };
+
+} // namespace library::tests
+
+#endif // !LIBRARY_TESTS_LIBRARYFACTORY_CPP

--- a/library/tests/src/MetaModelTests.cpp
+++ b/library/tests/src/MetaModelTests.cpp
@@ -1,19 +1,51 @@
-#include <boost/test/unit_test.hpp>
-#include "library/LibraryPackage.hpp"
 #include "ecore/EAttribute.hpp"
 #include "ecore/EClass.hpp"
+#include "ecore/EList.hpp"
+#include "ecore/EReference.hpp"
+#include "ecore/Stream.hpp"
+#include "library/LibraryPackage.hpp"
+
+#include <boost/test/unit_test.hpp>
 
 using namespace library;
 using namespace ecore;
 
+namespace std
+{
+    template <typename T>
+    ostream& operator<<( ostream& os, const std::vector<T>& v )
+    {
+        return print_container( os, v );
+    }
+
+    template <typename T>
+    bool operator==( const EList<T>& lhs, const std::vector<T>& rhs )
+    {
+        return lhs.size() == rhs.size() && std::equal( lhs.begin(), lhs.end(), rhs.begin() );
+    }
+} // namespace std
+
 BOOST_AUTO_TEST_SUITE( ModelTests )
 
-BOOST_AUTO_TEST_CASE( TestContainer )
+BOOST_AUTO_TEST_CASE( LendableCopiesContainer )
 {
     auto p = LibraryPackage::eInstance();
     auto a = p->getLendable_Copies();
-    BOOST_CHECK_EQUAL( std::static_pointer_cast<EObject>(p->getLendable()), a->eContainer() );
+    BOOST_CHECK_EQUAL( std::static_pointer_cast<EObject>( p->getLendable() ), a->eContainer() );
 }
 
+BOOST_AUTO_TEST_CASE( LibraryContainments )
+{
+    auto p = LibraryPackage::eInstance();
+    auto c = p->getLibrary();
+    auto con = c->getEContainments();
+    BOOST_CHECK_EQUAL( *con,
+                       std::vector<std::shared_ptr<EReference>>( {p->getLibrary_Writers(),
+                                                                  p->getLibrary_Employees(),
+                                                                  p->getLibrary_Borrowers(),
+                                                                  p->getLibrary_Stock(),
+                                                                  p->getLibrary_Books(),
+                                                                  p->getLibrary_Branches()} ) );
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/library/tests/src/SerializationTests.cpp
+++ b/library/tests/src/SerializationTests.cpp
@@ -1,12 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
-#include "library/Book.hpp"
-#include "library/Borrower.hpp"
-#include "library/Employee.hpp"
-#include "library/Library.hpp"
-#include "library/LibraryFactory.hpp"
+#include "LibraryFactory.hpp"
 #include "library/LibraryPackage.hpp"
-#include "library/Writer.hpp"
 
 #include "ecore/EResource.hpp"
 #include "ecore/EResourceFactory.hpp"
@@ -14,13 +9,11 @@
 #include "ecore/EPackageRegistry.hpp"
 #include "ecore/URI.hpp"
 
-#include <chrono>
-#include <random>
-#include <stack>
 #include <fstream>
 
 using namespace ecore;
 using namespace library;
+using namespace library::tests;
 
 namespace
 {
@@ -29,131 +22,13 @@ namespace
     constexpr int nb_books = 1000;
     constexpr int nb_borrowers = 100;
 
-    template <class TimePoint>
-    class uniform_time_distribution
-    {
-    public:
-        uniform_time_distribution( TimePoint start, TimePoint end )
-            : m_start( start )
-            , m_end( end )
-            , m_seconds( std::chrono::duration_cast<std::chrono::seconds>( end - start ) )
-        {
-        }
-
-        template <class Generator>
-        TimePoint operator()( Generator&& g )
-        {
-            std::uniform_int_distribution<std::chrono::seconds::rep> d( 0, m_seconds.count() );
-
-            return m_start + std::chrono::seconds( d( g ) );
-        }
-
-    private:
-        TimePoint m_start;
-        TimePoint m_end;
-        std::chrono::seconds m_seconds;
-    };
-
-    template <class TimePoint>
-    TimePoint randomTime( TimePoint start, TimePoint end )
-    {
-        static std::random_device rd;
-        static std::mt19937 gen( rd() );
-        uniform_time_distribution<TimePoint> t( start, end );
-        return t( gen );
-    }
-
 } // namespace
 
 BOOST_AUTO_TEST_SUITE( SerializationTests )
 
 BOOST_AUTO_TEST_CASE( GenerateModel, *boost::unit_test::disabled() )
 {
-    auto lf = LibraryFactory::eInstance();
-    auto lp = LibraryPackage::eInstance();
-
-    auto l = lf->createLibrary();
-    l->setName( "My Library" );
-    l->setAddress( "My Library Adress" );
-
-    std::default_random_engine generator;
-
-    // employees
-    auto employees = l->getEmployees();
-    for( int i = 0; i < nb_employees; ++i )
-    {
-        auto ndx = std::to_string( i );
-        auto e = lf->createEmployee();
-        e->setAddress( "Adress " + ndx );
-        e->setFirstName( "First Name " + ndx );
-        e->setLastName( "Last Name " + ndx );
-
-        if( !employees->empty() )
-        {
-            std::uniform_int_distribution<int> d( 0, static_cast<int>( employees->size() ) - 1 );
-            auto ndx = d( generator );
-            e->setManager( employees->get( ndx ) );
-        }
-
-        employees->add( e );
-    }
-
-    // writers
-    for( int i = 0; i < nb_writers; ++i )
-    {
-        auto w = lf->createWriter();
-        auto ndx = std::to_string( i );
-        w->setAddress( "Adress " + ndx );
-        w->setFirstName( "First Name " + ndx );
-        w->setLastName( "Last Name " + ndx );
-
-        l->getWriters()->add( w );
-    }
-
-    // books
-    std::uniform_int_distribution<int> book_author_distibution( 0, nb_writers > 0 ? nb_writers - 1 : 0 );
-    std::uniform_int_distribution<int> book_category_distibution( 0, 2 );
-    std::uniform_int_distribution<int> book_copies_distibution( 1, 5 );
-    std::uniform_int_distribution<int> book_pages_distibution( 1, 500 );
-    auto start_date = std::chrono::system_clock::from_time_t( std::time_t( 0 ) );
-    auto end_date = std::chrono::system_clock::now();
-    for( int i = 0; i < nb_books; ++i )
-    {
-        auto b = lf->createBook();
-        b->setCategory( BookCategory( book_category_distibution( generator ) ) );
-        b->setCopies( book_copies_distibution( generator ) );
-        b->setPages( book_pages_distibution( generator ) );
-        b->setPublicationDate( std::chrono::system_clock::to_time_t( randomTime( start_date, end_date ) ) );
-        b->setTitle( "Title " + std::to_string( i ) );
-
-        if constexpr( nb_writers > 0 )
-        {
-            auto authorNdx = book_author_distibution( generator );
-            auto a = l->getWriters()->get( authorNdx );
-            b->setAuthor( a );
-        }
-        
-        l->getBooks()->add( b );
-    }
-
-    // borrowers
-    std::uniform_int_distribution<int> borrower_book_distibution( 0, nb_borrowers > 0 ? nb_borrowers - 1 : 0 );
-    for( int i = 0; i < nb_borrowers; ++i )
-    {
-        auto b = lf->createBorrower();
-        auto ndx = std::to_string( i );
-        b->setAddress( "Adress " + ndx );
-        b->setFirstName( "First Name " + ndx );
-        b->setLastName( "Last Name " + ndx );
-
-        if constexpr ( nb_books > 0 )
-        {
-            auto bookNdx = borrower_book_distibution( generator );
-            auto book = l->getBooks()->get( bookNdx );
-            b->getBorrowed()->add( book );
-        }
-    }
-
+    auto l = LibraryFactory::createLibrary( nb_employees, nb_writers, nb_books, nb_borrowers );
     auto fileURI = URI("file:D:/dev/mylib.xml");
     auto resourceFactory = EResourceFactoryRegistry::getInstance()->getFactory( fileURI );
     BOOST_CHECK( resourceFactory );


### PR DESCRIPTION
An adapter that maintains itself as an adapter for all contained objects as they come and go.
It can be installed for an EObject