### PR TITLE
[ecore][cpp] Clear Resource when unloading

### DIFF
--- a/ecore/lib/src/ecore/EResourceIDManager.hpp
+++ b/ecore/lib/src/ecore/EResourceIDManager.hpp
@@ -22,6 +22,8 @@ namespace ecore
     public:
         virtual ~EResourceIDManager() = default;
 
+        virtual void clear() = 0;
+
         virtual void registerObject( const std::shared_ptr<EObject>& eObject ) = 0;
 
         virtual void unregisterObject( const std::shared_ptr<EObject>& eObject ) = 0;

--- a/ecore/lib/src/ecore/impl/AbstractResource.cpp
+++ b/ecore/lib/src/ecore/impl/AbstractResource.cpp
@@ -206,10 +206,14 @@ std::shared_ptr<EObject> AbstractResource::getObjectForRootSegment( const std::s
 
 void AbstractResource::attached( const std::shared_ptr<EObject>& object )
 {
+    if( resourceIDManager_ )
+        resourceIDManager_->registerObject( object );
 }
 
 void AbstractResource::detached( const std::shared_ptr<EObject>& object )
 {
+    if( resourceIDManager_ )
+        resourceIDManager_->unregisterObject( object );
 }
 
 void AbstractResource::load()
@@ -326,7 +330,11 @@ std::shared_ptr<ENotificationChain> AbstractResource::basicSetResourceSet( const
 
 void AbstractResource::doUnload()
 {
-    eContents_->clear();
+    eContents_.reset();
+    errors_.reset();
+    warnings_.reset();
+    if( resourceIDManager_)
+        resourceIDManager_->clear();
 }
 
 std::shared_ptr<URIConverter> AbstractResource::getURIConverter() const

--- a/ecore/lib/src/ecore/impl/ResourceIDManager.cpp
+++ b/ecore/lib/src/ecore/impl/ResourceIDManager.cpp
@@ -14,6 +14,12 @@ ResourceIDManager::~ResourceIDManager()
 {
 }
 
+void ResourceIDManager::clear()
+{
+    objectToID_.clear();
+    idToObject_.clear();
+}
+
 void ResourceIDManager::registerObject( const std::shared_ptr<EObject>& eObject )
 {
     auto id = EcoreUtils::getID( eObject );

--- a/ecore/lib/src/ecore/impl/ResourceIDManager.hpp
+++ b/ecore/lib/src/ecore/impl/ResourceIDManager.hpp
@@ -24,6 +24,8 @@ namespace ecore::impl
 
         virtual ~ResourceIDManager();
 
+        virtual void clear();
+
         virtual void registerObject( const std::shared_ptr<EObject>& eObject );
 
         virtual void unregisterObject( const std::shared_ptr<EObject>& eObject );


### PR DESCRIPTION
When unloading a resource , clear everything ( warnings/errors/content/ id manager )